### PR TITLE
Download binary for system arch

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -49,11 +49,31 @@ get_platform() {
   uname | tr '[:upper:]' '[:lower:]'
 }
 
+get_arch () {
+  local arch=""
+
+  case "$(uname -m)" in
+      x86_64|amd64) arch="amd64"; ;;
+      i686|i386) arch="386"; ;;
+      armv6l) arch="armv6"; ;;
+      armv7l) arch="armv7"; ;;
+      aarch64) arch="arm64"; ;;
+      ppc64le) arch="ppc64le"; ;;
+      *)
+        echo "Arch '$(uname -m)' not supported!" >&2
+        exit 1
+        ;;
+  esac
+
+  echo -n $arch
+}
+
 get_filename() {
   local -r version="$1"
   local -r platform="$2"
+  local -r arch="$(get_arch)"
 
-  echo "${app_name}-${version}-${platform}-amd64.tar.gz"
+  echo "${app_name}-${version}-${platform}-${arch}.tar.gz"
 }
 
 get_download_url() {


### PR DESCRIPTION
Get the machine harware name and convert into the corresponding Go
system arch. Copied from:

https://github.com/kennyp/asdf-golang/blob/master/bin/install#L21

~~~
$ ASDF_INSTALL_TYPE=foo ASDF_INSTALL_VERSION=1.29.0 ASDF_INSTALL_PATH=/tmp/foo bin/install
Downloading golangci-lint from
https://github.com/golangci/golangci-lint/releases/download/v1.29.0/golangci-lint-1.29.0-linux-arm64.tar.gz
to /tmp/golangci-lint_8FekQl/golangci-lint-1.29.0-linux-arm64.tar.gz
Creating bin directory
Cleaning previous binaries
Copying binary
Cleaning up downloads
~~~