### PR TITLE
Add legacy file support

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,1 @@
+.golangci.yml

--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,1 +1,1 @@
-.golangci.yml
+.golangci.yml .golangci.yaml

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+get_legacy_version() {
+  local file current_version
+
+  file="$1"
+  current_version="$(awk -F: '/golangci-lint-version/{gsub("#.*$", "", $0); print $2}' "$file")"
+  # remove leading whitespace characters
+  current_version="${current_version#"${current_version%%[![:space:]]*}"}"
+  # remove trailing whitespace characters
+  current_version="${current_version%"${current_version##*[![:space:]]}"}"
+
+  case "$current_version" in
+    *.x*)
+      printf "latest:%s" "${current_version%.x}"
+      ;;
+    *)
+      printf "%s" "$current_version"
+      ;;
+  esac
+}
+
+get_legacy_version "$1"


### PR DESCRIPTION
This adds legacy file support. It parses the `.golangci.yml`/`.golangci.yaml` and retrieves the version selected from `service.golangci-lint-version`. This is a best effort as it's not easy to parse yaml with bash.