### PR TITLE
Handle other architectures (support M1 Mac)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -49,11 +49,31 @@ get_platform() {
   uname | tr '[:upper:]' '[:lower:]'
 }
 
+get_arch () {
+  local arch=""
+
+  case "$(uname -m)" in
+      x86_64|amd64) arch="amd64"; ;;
+      i686|i386) arch="386"; ;;
+      armv6l) arch="armv6"; ;;
+      armv7l) arch="armv7"; ;;
+      aarch64|arm64) arch="arm64"; ;;
+      ppc64le) arch="ppc64le"; ;;
+      *)
+        echo "Arch '$(uname -m)' not supported!" >&2
+        exit 1
+        ;;
+  esac
+
+  echo -n $arch
+}
+
 get_filename() {
   local -r version="$1"
   local -r platform="$2"
+  local -r arch="$(get_arch)"
 
-  echo "${app_name}-${version}-${platform}-amd64.tar.gz"
+  echo "${app_name}-${version}-${platform}-${arch}.tar.gz"
 }
 
 get_download_url() {


### PR DESCRIPTION
This is a slightly amended version of #3 that also works on an M1 Mac. :)

```shell
$ asdf install golangci-lint latest
Downloading golangci-lint from https://github.com/golangci/golangci-lint/releases/download/v1.43.0/golangci-lint-1.43.0-darwin-arm64.tar.gz to /var/folders/yd/hh1qxzb115j1pr0z6kt7lx000000gn/T//golangci-lint-1.43.0-darwin-arm64.tar.gz
Creating bin directory
Cleaning previous binaries
Copying binary
Cleaning up downloads
$
```

I did this because I got this error when running `golangci-lint` which was because it was for `amd64` instead of `ARM64`:
```shell
$ golangci-lint -h
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.9()
	github.com/go-critic/go-critic@v0.6.1/checkers/checkers.go:58 +0x4b4
$
```