### PR TITLE
Fail fast when curl downloads fail

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -28,7 +28,7 @@ install_golangci_lint() {
   local -r download_path="${tmp_download_dir}/${filename}"
 
   echo "Downloading ${app_name} from ${download_url} to ${download_path}"
-  curl -sSLo ${download_path} ${download_url}
+  curl --fail -sSLo ${download_path} ${download_url}
 
   echo "Creating bin directory"
   mkdir -p "${bin_install_path}"


### PR DESCRIPTION
Previously if a missing golangci-lint version were specified, curl would quietly suceeed, but the `tar` would fail. For example, if you specify `golangci-lint` with `1.65.0` today, you see:

```
Downloading golangci-lint from https://github.com/golangci/golangci-lint/releases/download/v1.65/golangci-lint-1.65-darwin-arm64.tar.gz to /var/folders/k4/mbnh565n4wg6xpbqv45tv91h0000gn/T//golangci-lint-1.65-darwin-arm64.tar.gz
Creating bin directory
Cleaning previous binaries
Copying binary
tar: Error opening archive: Unrecognized archive format
```

This change causes the download step to fail first so the error is clearer:

```
Downloading golangci-lint from https://github.com/golangci/golangci-lint/releases/download/v1.65/golangci-lint-1.65-darwin-arm64.tar.gz to /var/folders/k4/mbnh565n4wg6xpbqv45tv91h0000gn/T//golangci-lint-1.65-darwin-arm64.tar.gz
curl: (56) The requested URL returned error: 404
```